### PR TITLE
Add support for PHP 8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ environment:
     COMPOSER_NO_INTERACTION: 1
     ANSICON: 121x90 (121x90) # Console colors
 
-  ffmpeg_download: https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-4.3.1-2020-10-01-essentials_build.zip
+  ffmpeg_download: https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-4.3.2-2021-02-27-essentials_build.zip
 
   matrix:
     - PHP_VERSION: Latest_Version
@@ -29,8 +29,8 @@ install:
   - ps: cinst php --params '""/InstallDir:C:\tools\php""' --ignore-checksums
   - ps: Start-FileDownload $env:ffmpeg_download
 
-  - 7z x ffmpeg-4.3.1-2020-10-01-essentials_build.zip
-  - PATH=%PATH%;%cd%\ffmpeg-4.3.1-2020-10-01-essentials_build\bin
+  - 7z x ffmpeg-4.3.2-2021-02-27-essentials_build.zip
+  - PATH=%PATH%;%cd%\ffmpeg-4.3.2-2021-02-27-essentials_build\bin
   - cd c:\tools\php
   - copy php.ini-production php.ini /Y
   - echo date.timezone="UTC" >> php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 8.0
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,8 @@
         }
     },
     "require": {
-        "php": "^7.2",
-        "php-ffmpeg/php-ffmpeg": "^0.15 || 0.16",
+        "php": "^7.2 || ^8.0",
+        "php-ffmpeg/php-ffmpeg": "^0.15 || 0.16 || 0.17 || 0.18",
         "symfony/filesystem": "^4.0 || ^5.0"
     },
     "suggest": {


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | 
| Related issues/PRs | 
| License            | MIT

#### What's in this PR?

Support for PHP 8 and the recent php-ffmpeg version.

PHP 8 support was added to php-ffmpeg with version 0.17, so I decided to add support for that version and the more recent 0.18.